### PR TITLE
Symmetry: de-randomize torso/neck/head/nose/mouth

### DIFF
--- a/makehuman/plugins/0_modeling_8_random.py
+++ b/makehuman/plugins/0_modeling_8_random.py
@@ -130,12 +130,11 @@ def randomize(human, symmetry, macro, height, face, body):
     for m in modifiers:
         if m.fullName not in randomValues:
             randomValue = None
-            if m.groupName == 'head':
-                sigma = 0.1
-            elif m.fullName in ["forehead/forehead-nubian-less|more", "forehead/forehead-scale-vert-less|more"]:
+            if m.fullName in ["forehead/forehead-nubian-less|more", "forehead/forehead-scale-vert-less|more"]:
                 sigma = 0.02
                 # TODO add further restrictions on gender-dependent targets like pregnant and breast
-            elif "trans-horiz" in m.fullName or m.fullName == "hip/hip-trans-in|out":
+            elif m.fullName in ["hip/hip-trans-in|out", "torso/torso-trans-in|out", "neck/neck-trans-in|out", \
+                                "head/head-trans-in|out", "nose/nose-trans-in|out", "mouth/mouth-trans-in|out"]:
                 if symmetry == 1:
                     randomValue = m.getDefaultValue()
                 else:
@@ -145,7 +144,7 @@ def randomize(human, symmetry, macro, height, face, body):
                     mMin = max(mMin, m.getDefaultValue() - w/2)
                     mMax = min(mMax, m.getDefaultValue() + w/2)
                     randomValue = getRandomValue(mMin, mMax, m.getDefaultValue(), 0.1)
-            elif m.groupName in ["forehead", "eyebrows", "neck", "eyes", "nose", "ears", "chin", "cheek", "mouth"]:
+            elif m.groupName in ["head", "forehead", "eyebrows", "neck", "eyes", "nose", "ears", "chin", "cheek", "mouth"]:
                 sigma = 0.1
             elif m.groupName == 'macrodetails':
                 # TODO perhaps assign uniform random values to macro modifiers?


### PR DESCRIPTION
I am adding "torso/torso-trans-in|out", "neck/neck-trans-in|out", "head/head-trans-in|out", "nose/nose-trans-in|out" and "mouth/mouth-trans-in|out" so that they're de-randomized following an increase of the Symmetry slider, in the same way as "hip/hip-trans-in|out".
Initially those parameters were partly taken care of by checking for ("trans-horiz" in m.fullName), but then "neck/neck-trans-horiz-in|out", "nose/nose-trans-horiz-in|out" and "torso/torso-trans-horiz-in|out" were renamed in 1.1.0, so the check became ineffective (that's why I am removing it now). It seems that "mouth/mouth-trans-in|out" and "head/head-trans-in|out" weren't handled properly even in 1.0.2.

I am moving the (m.groupName == "head") filter down, so that it comes after the "head/head-trans-in|out" filter. Since all those other groups have sigma = 0.1 too, I just put them all together.

The current behavior (with non-suppressed lateral shift of torso/neck/head/nose/mouth) is shown below.
![symmetry](https://user-images.githubusercontent.com/40238190/50057413-596d3080-016a-11e9-9a1e-397a3aca87fe.png)