### PR TITLE
expression mixer: fix sluggish slider

### DIFF
--- a/makehuman/plugins/7_expression_mixer.py
+++ b/makehuman/plugins/7_expression_mixer.py
@@ -150,8 +150,9 @@ class ExpressionMixerTaskView(gui3d.TaskView):
         posenames = []
         posevalues = []
         for pname,pval in self.modifiers.items():
-            posenames.append(pname)
-            posevalues.append(pval)
+            if pval != 0:
+                posenames.append(pname)
+                posevalues.append(pval)
         if len(posenames) == 0:
             return
 


### PR DESCRIPTION
There was a regression introduced in the recent commit 51ee3631818184feabc808db16dfc3bacdff80f2 "add load option to expression mixer": the expression mixer ui sliders became very slow. (3-5 times slower)
This commit fixes it by reverting the relevant code.