### PR TITLE
qtgui: workaround with incorrect QLabel size

### DIFF
--- a/makehuman/lib/qtgui.py
+++ b/makehuman/lib/qtgui.py
@@ -825,6 +825,17 @@ class TextView(QtWidgets.QLabel, Widget):
         text = getLanguageString(text)
         super(TextView,self).setText(text % values)
 
+    # Workaround for incorrect resizing with enabled word wrapping
+    # https://bugreports.qt.io/browse/QTBUG-37673
+    def resizeEvent(self, event):
+        super(TextView, self).resizeEvent(event)
+
+        if self.wordWrap():
+            # heightForWidth rely on minimumSize to evaulate, so reset it before
+            self.setMinimumHeight(0)
+            # define minimum height
+            self.setMinimumHeight(self.heightForWidth(self.width()))
+
 class SliderBox(GroupBox):
     pass
 


### PR DESCRIPTION
Use workaround for incorrect QLabel size if word wrapping enabled.
For more information, look QTBUG-37673.

That bug causes QLabel and derived classes (TextView in MH) to cut
several lines if word wrapping is enabled.
Bug "in the wild": information in left panel of "User plugins".

Without the fix there are several "eated" lines of text:
![no_patch](https://user-images.githubusercontent.com/7457530/74685915-fc8f5f00-51e0-11ea-92c5-7674380b7ea5.png)
With the fix all text displayed:
![patched](https://user-images.githubusercontent.com/7457530/74685936-09ac4e00-51e1-11ea-9c3d-31f44a9f22f4.png)

