### PR TITLE
Introduce pre-startup config scan, and some additional stuff for HDPI

### DIFF
--- a/makehuman/core/mhmain.py
+++ b/makehuman/core/mhmain.py
@@ -768,11 +768,6 @@ class MHApplication(gui3d.Application, mh.Application):
 
         #self.splash.setFormat('<br><br><b><font size="10" color="#ffffff">%s</font></b>')
 
-        #Use HDPI settings
-        if self.getSetting('useHDPI'):
-            os.environ["QT_AUTO_SCREEN_SCALE_FACTOR"] = "1"
-            self.setAttribute(gui.QtCore.Qt.AA_EnableHighDpiScaling)
-
         progress = Progress([36, 6, 15, 333, 40, 154, 257, 5], messaging=True)
 
         progress.firststep('Loading human')

--- a/makehuman/lib/core.py
+++ b/makehuman/lib/core.py
@@ -72,6 +72,7 @@ class Globals(object):
             for key in _PRE_STARTUP_KEYS:
                 if key in data:
                     self.preStartupSettings[key] = data[key]
+                    # Would be nice to log this, but log has not been initialized yet
                     print("PRE STARTUP SETTING: " + key + " = " + str(data[key]))
                 else:
                     self.preStartupSettings[key] = None

--- a/makehuman/lib/core.py
+++ b/makehuman/lib/core.py
@@ -38,6 +38,11 @@ TODO
 
 import importlib
 import importlib.util
+import os, json
+
+from getpath import getPath
+
+_PRE_STARTUP_KEYS = ["useHDPI"]
 
 class Globals(object):
     def __init__(self):
@@ -49,6 +54,26 @@ class Globals(object):
         self.windowHeight = 600
         self.windowWidth = 800
         self.clearColor = (0.0, 0.0, 0.0, 0.0)
+        self.preStartupSettings = dict()
+        self._preStartupConfigScan()
+
+    def _preStartupConfigScan(self):
+        """Run a very primitive scan in order to pick up settings which has
+        to be known before we launch the QtApplication object."""
+        iniPath = getPath("settings.ini")
+        data = None
+        if os.path.exists(iniPath):
+            with open(iniPath) as f:
+                data = json.load(f)
+        if data is None:
+            for key in _PRE_STARTUP_KEYS:
+                self.preStartupSettings[key] = None
+        else:
+            for key in _PRE_STARTUP_KEYS:
+                if key in data:
+                    self.preStartupSettings[key] = data[key]
+                    print("PRE STARTUP SETTING: " + key + " = " + str(data[key]))
+                else:
+                    self.preStartupSettings[key] = None
 
 G = Globals()
-

--- a/makehuman/lib/qtui.py
+++ b/makehuman/lib/qtui.py
@@ -688,6 +688,9 @@ class AsyncEvent(QtCore.QEvent):
 
 class Application(QtWidgets.QApplication, events3d.EventHandler):
     def __init__(self):
+        if "useHDPI" in G.preStartupSettings and G.preStartupSettings["useHDPI"]:
+            print("Trying to enable HDPI before launching Qt application")
+            os.environ["QT_AUTO_SCREEN_SCALE_FACTOR"] = "1"
         super(Application, self).__init__(sys.argv)
         self.mainwin = None
         self.log_window = None
@@ -702,6 +705,8 @@ class Application(QtWidgets.QApplication, events3d.EventHandler):
         self.eventHandlers = []
         # self.installEventFilter(self)
         QtGui.qt_set_sequence_auto_mnemonic(False)
+        if "useHDPI" in G.preStartupSettings and G.preStartupSettings["useHDPI"]:
+            self.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling)
 
     def OnInit(self):
         import debugdump

--- a/makehuman/lib/qtui.py
+++ b/makehuman/lib/qtui.py
@@ -689,8 +689,11 @@ class AsyncEvent(QtCore.QEvent):
 class Application(QtWidgets.QApplication, events3d.EventHandler):
     def __init__(self):
         if "useHDPI" in G.preStartupSettings and G.preStartupSettings["useHDPI"]:
+            # Would be nice to log this, but log has not been initialized yet
             print("Trying to enable HDPI before launching Qt application")
             os.environ["QT_AUTO_SCREEN_SCALE_FACTOR"] = "1"
+            # Forward compatibility, since the AUTO_SCREEN* env variable is marked as deprecated in pyqt 5.14
+            os.environ["QT_ENABLE_HIGHDPI_SCALING"] = "1"
         super(Application, self).__init__(sys.argv)
         self.mainwin = None
         self.log_window = None


### PR DESCRIPTION
Here I've introduced an early configuration sweep in order to be able so set the QT_AUTO_SCREEN_SCALE_FACTOR _before_ the Qt application launches. 

@dennj can you check if this works for you on your monitor?

@rwbaer can you check that it doesn't cause trouble on your dual monitor setup?
