### PR TITLE
Remove commas from apt-get install line

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ If you rather run the code from source:
 
 All that you need should be available via apt. On a console prompt, run:
 
-* apt-get install python3-numpy, python3-opengl, python3-pyqt5, python3-pyqt5.qtopengl, python3-pyqt5.qtsvg
+* apt-get install python3-numpy python3-opengl python3-pyqt5 python3-pyqt5.qtopengl python3-pyqt5.qtsvg
 
 ### Installing python dependencies on windows
 


### PR DESCRIPTION
I tried to install the packages and got this error message from apt:

E: Unable to locate package python3-numpy,
E: Unable to locate package python3-opengl,
E: Unable to locate package python3-pyqt5,
E: Unable to locate package python3-pyqt5.qtopengl,
E: Couldn't find any package by glob 'python3-pyqt5.qtopengl,'
E: Couldn't find any package by regex 'python3-pyqt5.qtopengl,'