### PR TITLE
Fix freezing About / License dialog on macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,7 +78,12 @@ ehthumbs.db
 Thumbs.db
 /venv*
 
-# Builds #
-##########
+# macOS Build Files #
+#####################
 /buildscripts/darwin/build/*
 /buildscripts/darwin/dist/*
+/buildscripts/darwin/.eggs/*
+
+# Python Packages #
+###################
+.eggs/*

--- a/makehuman/lib/qtgui.py
+++ b/makehuman/lib/qtgui.py
@@ -52,7 +52,7 @@ from getpath import getSysDataPath, getPath, isSubPath, pathToUnicode
 def dummySvgCall():
     """Code which is here just so pyinstaller can discover we need SVG support"""
     dummy = QtSvg.QGraphicsSvgItem("some_svg.svg")
-    
+
 def getLanguageString(text, appendData=None, appendFormat=None):
     """Function to get the translation of a text according to the selected
     language.
@@ -1230,8 +1230,10 @@ class AboutBoxScrollbars(QtWidgets.QDialog):
             re_match_urls = re.compile(r"""((?:[a-z][\w-]+:(?:/{1,3}|[a-z0-9%])|www\d{0,3}[.]|[a-z0-9.\-]+[.‌​][a-z]{2,4}/)(?:[^\s()<>]+|(([^\s()<>]+|(([^\s()<>]+)))*))+(?:(([^\s()<>]+|(‌​([^\s()<>]+)))*)|[^\s`!()[]{};:'".,<>?«»“”‘’]))""", re.DOTALL)
             return re_match_urls.sub(lambda x: '<a href="%(url)s" style="color: #ffa02f;">%(url)s</a>' % dict(url=str(x.group())), text)
 
-        if sys.platform.startswith('darwin'):
-            self.setWindowFlags(QtCore.Qt.WindowTitleHint | QtCore.Qt.WindowSystemMenuHint)
+        # Causes whole app to hang
+        # if sys.platform.startswith('darwin'):
+        #     self.setWindowFlags(QtCore.Qt.WindowTitleHint | QtCore.Qt.WindowSystemMenuHint)
+
         # Grab window icon of parent
         icon = self.windowIcon()
         size = icon.actualSize(QtCore.QSize(64, 64))

--- a/makehuman/makehuman.py
+++ b/makehuman/makehuman.py
@@ -146,7 +146,8 @@ def set_sys_path():
         sys.path = syspath
     else:
         data_path = "../Resources/makehuman"
-        os.chdir(data_path)
+        if(os.path.isdir(data_path)):
+            os.chdir(data_path)
         syspath = ["./lib", "./apps", "./shared", "./apps/gui", "./core", "../lib", "../"]
         syspath.extend(sys.path)
         sys.path = syspath


### PR DESCRIPTION
About / License window caused the program to hang on macOS. As soon as you click the "About / License" button, the program would become unresponsive. I removed the following block to open that dialog in a new window:

```
if sys.platform.startswith('darwin'):
    self.setWindowFlags(QtCore.Qt.WindowTitleHint | QtCore.Qt.WindowSystemMenuHint)
```
Now it doesn't become unresponsive. The window still has some performance problems, and it feels a bit laggy but it doesn't affect the main window and you can close it.