### PR TITLE
Python 3.10 fixes

### DIFF
--- a/makehuman/apps/gui/guimodifier.py
+++ b/makehuman/apps/gui/guimodifier.py
@@ -201,7 +201,7 @@ class GroupBoxRadioButton(gui.RadioButton):
 
 def _getCamFunc(cameraName):
     if cameraName:
-        if hasattr(gui3d.app, cameraName) and isinstance(getattr(gui3d.app, cameraName), collections.Callable):
+        if hasattr(gui3d.app, cameraName) and isinstance(getattr(gui3d.app, cameraName), collections.abc.Callable):
             return cameraName
 
         return "set" + cameraName.upper()[0] + cameraName[1:]

--- a/makehuman/core/guicommon.py
+++ b/makehuman/core/guicommon.py
@@ -142,7 +142,7 @@ class Object(events3d.EventHandler):
 
     @property
     def view(self):
-        if not self._view or not isinstance(self._view, collections.Callable):
+        if not self._view or not isinstance(self._view, collections.abc.Callable):
             return None
         return self._view()
 

--- a/makehuman/lib/language.py
+++ b/makehuman/lib/language.py
@@ -43,13 +43,13 @@ import log
 import json
 from getpath import getPath, getSysDataPath, getDataPath
 
-import collections
+from collections import OrderedDict
 
 class Language(object):
     def __init__(self):
         self.language = None
         self.languageStrings = None
-        self.missingStrings = OrderedSet()
+        self.missingStrings = OrderedDict()
         self.rtl = False
 
     def setLanguage(self, lang):
@@ -95,7 +95,7 @@ class Language(object):
                 else:
                     result = result + appendData
             return result
-        self.missingStrings.add(string)
+        self.missingStrings[string] = None
         return string
             
     def dumpMissingStrings(self):
@@ -106,77 +106,12 @@ class Language(object):
         if not os.path.isdir(pathdir):
             os.makedirs(pathdir)
         with open(path, 'w', encoding='utf-8') as f:
-            for string in self.missingStrings:
+            for string in self.missingStrings.keys():
                 if self.language == "master":
                     f.write('"%s": "%s",\n' % (string.replace('\n', '\\n').encode('utf8'), string.replace('\n', '\\n').encode('utf8')))
                 else:
                     f.write('"%s": "",\n' % string.replace('\n', '\\n').encode('utf8'))
 
-
-class OrderedSet(collections.MutableSet):
-    """
-    Set that maintains insertion order.
-
-    This is a python recipe, as referenced in the official documentation
-    (http://docs.python.org/2/library/collections.html)
-    Source: http://code.activestate.com/recipes/576694/
-    """
-
-    def __init__(self, iterable=None):
-        self.end = end = [] 
-        end += [None, end, end]         # sentinel node for doubly linked list
-        self.map = {}                   # key --> [key, prev, next]
-        if iterable is not None:
-            self |= iterable
-
-    def __len__(self):
-        return len(self.map)
-
-    def __contains__(self, key):
-        return key in self.map
-
-    def add(self, key):
-        if key not in self.map:
-            end = self.end
-            curr = end[1]
-            curr[2] = end[1] = self.map[key] = [key, curr, end]
-
-    def discard(self, key):
-        if key in self.map:        
-            key, prev, next = self.map.pop(key)
-            prev[2] = next
-            next[1] = prev
-
-    def __iter__(self):
-        end = self.end
-        curr = end[2]
-        while curr is not end:
-            yield curr[0]
-            curr = curr[2]
-
-    def __reversed__(self):
-        end = self.end
-        curr = end[1]
-        while curr is not end:
-            yield curr[0]
-            curr = curr[1]
-
-    def pop(self, last=True):
-        if not self:
-            raise KeyError('set is empty')
-        key = self.end[1][0] if last else self.end[2][0]
-        self.discard(key)
-        return key
-
-    def __repr__(self):
-        if not self:
-            return '%s()' % (self.__class__.__name__,)
-        return '%s(%r)' % (self.__class__.__name__, list(self))
-
-    def __eq__(self, other):
-        if isinstance(other, OrderedSet):
-            return len(self) == len(other) and list(self) == list(other)
-        return set(self) == set(other)
 
 def getLanguages():
     """

--- a/makehuman/lib/log.py
+++ b/makehuman/lib/log.py
@@ -245,9 +245,7 @@ def init():
 
     config()
 
-    # Compatibility test for Python 2.6 logging module
-    if hasattr(logging, "captureWarnings") and isinstance(logging.captureWarnings, collections.Callable):
-        logging.captureWarnings(True)
+    logging.captureWarnings(True)
 
     try:
         logging.getLogger('OpenGL.formathandler').addFilter(NoiseFilter())

--- a/makehuman/lib/qtgui.py
+++ b/makehuman/lib/qtgui.py
@@ -955,7 +955,7 @@ class ProgressBar(QtWidgets.QProgressBar, Widget):
     def setProgress(self, progress):
         min_ = self.minimum()
         max_ = self.maximum()
-        self.setValue(min_ + progress * (max_ - min_))
+        self.setValue(round(min_ + progress * (max_ - min_)))
 
 class ShortcutEdit(QtWidgets.QLabel, Widget):
     def __init__(self, shortcut):

--- a/makehuman/lib/qtui.py
+++ b/makehuman/lib/qtui.py
@@ -354,7 +354,7 @@ class VLayout(QtWidgets.QLayout):
         return width, y
 
     def sizeHint(self):
-        width, height = self._doLayout(0, 0, 1e9, 1e9, False)
+        width, height = self._doLayout(0, 0, int(1e9), int(1e9), False)
         return QtCore.QSize(width, height)
 
     def maximumSize(self):


### PR DESCRIPTION
This fixes issues that caused makehuman to crash during startup when using Python 3.10.1.

Notably `collections.Callable` and `collections.MutableSet` are moved to `collections.abc` submodule. I did also some refactoring to remove the `OrderedSet` class from `language.py` removing the need to use `MutableSet`.

There is also fix for PyQt5 throwing a ValueError during startup. I don't know if it was caused by Python 3.10 update or PyQt update. I am using PyQt 5.15.6.