### PR TITLE
Qt OpenGL update from QGLWidget to QOpenGLWidget to fix blank window …

### DIFF
--- a/makehuman/lib/glmodule.py
+++ b/makehuman/lib/glmodule.py
@@ -1058,6 +1058,6 @@ def draw(productionRender = False):
 
 def renderToCanvas():
     if draw():
-        G.canvas.swapBuffers()
+        # G.canvas.swapBuffers()
         # Indicate that picking buffer is out of sync with rendered frame (deferred update)
         markPickingBufferDirty()

--- a/makehuman/lib/qtui.py
+++ b/makehuman/lib/qtui.py
@@ -175,24 +175,24 @@ g_mouse_pos = None
 gg_mouse_pos = None
 g_mousewheel_t = None
 
-class Canvas(QtOpenGL.QGLWidget):
+class Canvas(QtWidgets.QOpenGLWidget):
     def __init__(self, parent, app):
         self.app = app
         self.blockRedraw = False
-        format = QtOpenGL.QGLFormat()
-        format.setAlpha(True)
+        format = QtGui.QSurfaceFormat()
+        format.setAlphaBufferSize(8)
         format.setDepthBufferSize(24)
+        format.setSwapBehavior(QtGui.QSurfaceFormat.DoubleBuffer)
         if not G.preStartupSettings["noSampleBuffers"]:
-            format.setSampleBuffers(True)
             format.setSamples(4)
-        super(Canvas, self).__init__(format, parent)
+        super(Canvas, self).__init__(parent)
+        self.setFormat(format)
         self.create()
 
     def create(self):
         G.canvas = self
         self.setFocusPolicy(QtCore.Qt.TabFocus)
         self.setFocus()
-        self.setAutoBufferSwap(False)
         self.setAutoFillBackground(False)
         self.setAttribute(QtCore.Qt.WA_NativeWindow)
         self.setAttribute(QtCore.Qt.WA_NoSystemBackground, False)


### PR DESCRIPTION
After updating to Kubuntu 22.04 I found that Makehuman would run, but the main window is simply black and blank.
I think this problem is likely to be shared by other users.
When reviewing the Qt python documentation, I saw that QGLWidget has been deprecated since December 2014 (Qt v5.4) and
should be replaced with QOpenGLWidget - I also had to change some of the function calls, which have changed between these widgets.
I made this replacement and it fixed my problem - I am once more able to see the default human when atarting makehuman,
and so far all functions seem to be working.
