### PR TITLE
Enables the 'edit' textbox for all Sliders

### DIFF
--- a/makehuman/core/mhmain.py
+++ b/makehuman/core/mhmain.py
@@ -231,6 +231,7 @@ class MHApplication(gui3d.Application, mh.Application):
                 'units': 'metric',
                 'real_weight': False,
                 'guiTheme': 'makehuman',
+                'sliderEditWidgetVisibility': False,
                 'restoreWindowSize': True,
                 'windowGeometry': '',
                 'useHDPI': False,
@@ -265,6 +266,7 @@ class MHApplication(gui3d.Application, mh.Application):
                 'rtl': False,
                 'sliderImages': True,
                 'guiTheme': 'makehuman',
+                'sliderEditWidgetVisibility': False,
                 'preloadTargets': False,
                 'restoreWindowSize': True,
                 'windowGeometry': '',
@@ -791,6 +793,10 @@ class MHApplication(gui3d.Application, mh.Application):
             self.setTheme(self.getSetting('guiTheme'))
         except:
             self.setTheme("default")
+        try:
+            self.setSliderEditWidgetVisibility(self.getSetting('sliderEditWidgetVisibility'))
+        except:
+            self.setSliderEditWidgetVisibility(False)
 
         progress.step('Applying targets')
         self.loadFinish()
@@ -1030,6 +1036,12 @@ class MHApplication(gui3d.Application, mh.Application):
             log.error('Failed to save settings file', exc_info=True)
             if promptOnFail:
                 self.prompt('Error', 'Could not save settings file.', 'OK')
+
+    def setSliderEditWidgetVisibility(self, isVisible):
+        for widget in self.allWidgets():
+            if isinstance(widget, gui.Slider):
+                widget.setEditWidgetVisibility(isVisible)
+
 
     # Themes
     def setTheme(self, theme):

--- a/makehuman/plugins/5_settings_0_settings.py
+++ b/makehuman/plugins/5_settings_0_settings.py
@@ -90,6 +90,24 @@ class ThemeRadioButton(gui.RadioButton):
             gui3d.app.setSetting('guiTheme', self.theme)
             gui3d.app.setTheme(self.theme)
 
+class SliderEditWidgetVisibilityRadioButton(gui.RadioButton):
+    def __init__(self, group, label, sliderEditWidgetVisibility):
+        self.sliderEditWidgetVisibility = sliderEditWidgetVisibility
+        checked = (gui3d.app.getSetting('sliderEditWidgetVisibility') == self.sliderEditWidgetVisibility)
+        super(SliderEditWidgetVisibilityRadioButton, self).__init__(group, label, checked)
+
+    def onClicked(self, event):
+        self.updated()
+
+    def updateButton(self, value):
+        self.setChecked(value)
+        self.updated()
+
+    def updated(self):
+        if self.selected:
+            gui3d.app.setSetting('sliderEditWidgetVisibility', self.sliderEditWidgetVisibility)
+            gui3d.app.setSliderEditWidgetVisibility(self.sliderEditWidgetVisibility)
+
 class PlatformRadioButton(gui.RadioButton):
     def __init__(self, group, looknfeel):
         super(PlatformRadioButton, self).__init__(group, looknfeel, gui3d.app.getLookAndFeel().lower() == looknfeel.lower())
@@ -217,6 +235,11 @@ class SettingsTaskView(gui3d.TaskView):
         self.themesBox = self.addRightWidget(gui.GroupBox('Theme'))
         self.themeNative = self.themesBox.addWidget(ThemeRadioButton(themes, "Native look", "default"))
         self.themeMH = self.themesBox.addWidget(ThemeRadioButton(themes, "MakeHuman", "makehuman"))
+
+        sliderEditWidgetVisibilities = []
+        self.sliderEditWidgetVisibilityBox = self.addRightWidget(gui.GroupBox('Slider\'s Edit Widget Visibility'))
+        self.sliderEditWidgetVisibilityVisible = self.sliderEditWidgetVisibilityBox.addWidget(SliderEditWidgetVisibilityRadioButton(sliderEditWidgetVisibilities, "Visible", True))
+        self.sliderEditWidgetVisibilityDefault = self.sliderEditWidgetVisibilityBox.addWidget(SliderEditWidgetVisibilityRadioButton(sliderEditWidgetVisibilities, "Default", False))
 
         # For debugging themes on multiple platforms
         '''


### PR DESCRIPTION
Problem: We want to copy/paste a slider's value to another. For instance
we want to copy the left-arm's lowerarm-muscles to the right-arm's
lowerarm-muscles.

Solution: Enables the textbox value editor for all Sliders. We do this
by setting a no-op value converter if none is specified. The no-op value
converter simply copy the input to its output. We also fix small bugs,
like sending 'onChanging' events when 'setValue()' is called. If not,
derived classes like ModifierSlider won't update correctly.