### PR TITLE
Bugfix: combobox is unreadable with 'native' theme

### DIFF
--- a/makehuman/data/themes/makehuman.qss
+++ b/makehuman/data/themes/makehuman.qss
@@ -145,6 +145,12 @@ QComboBox
     border-style: solid;
     border: 1px solid #1e1e1e;
     border-radius: 5;
+    color: white;
+    /*
+     * Padding is because Qt has a bug that ignores style color in a 
+     * combobox without it (for some incomprehensible reason)
+     */
+    padding: 2px;
 }
 
 QComboBox:hover,QPushButton:hover

--- a/makehuman/plugins/1_mhapi/_ui.py
+++ b/makehuman/plugins/1_mhapi/_ui.py
@@ -45,10 +45,6 @@ class ComboBox(QComboBox, QWidget):
         if onChange:
             self.onChangeMethod = onChange
 
-        # Padding is because Qt has a bug that ignores style color in a 
-        # combobox without it (for some incomprehensible reason)
-        self.setStyleSheet("QComboBox { color: white; padding: 2px }")
-
     def setData(self,items):
         self.clear()
         for item in items:


### PR DESCRIPTION
Problem: Combobox is unreadable when using the 'native' theme because
the foreground color is set to white and the 'native' background is
light-grey.

Solution: Remove the hard-coded stylesheet set by the ComboBox
constructor and moves it in the 'makehuman.qss' stylesheet.

Note: Apparently calling setStylesheet in the constructor makes the
stylesheet's value the 'default'. Thus when we later call
'setStylesheet("")' the stylesheet values set by the constructor are
preserved.