### PR TITLE
Fix compile_targets.py when using numpy 1.24.0 or newer

### DIFF
--- a/makehuman/makehuman.py
+++ b/makehuman/makehuman.py
@@ -403,7 +403,7 @@ Homepage: %s""" % (self.author, self.license, self.copyright, self.homepage)
                 text += key + value
             text = np.fromstring(text, dtype='S1')
             index = np.array(index, dtype=np.uint32)
-            return text, index
+            return np.array([text, index], dtype=object)
 
         return _packStringDict(self.asDict())
 


### PR DESCRIPTION
Fixes #217

Numpy 1.24.0 removed creation of arrays with mismatched dimensions to have implicit `dtype=object`. To maintain the old behavior, `dtype=object` has to be specified explicitly.

https://numpy.org/neps/nep-0034-infer-dtype-is-object.html

This changes the return type of `LicenseInfo.toNumpyString()` to a numpy array. The method is used in three places:
- [compile_targets.py](../blob/d9d4db7076c63ff39bc63f8bffd7acdcd0689cfe/makehuman/compile_targets.py#L74): Previously the tuple return value was converted to a numpy array implicitly by the `np.save` method. With this change, it gets a numpy array instead of a tuple, so the behavior is exactly the same as with older numpy versions.
- [core/algos3d.py](../blob/d9d4db7076c63ff39bc63f8bffd7acdcd0689cfe/makehuman/core/algos3d.py#L226): The return value is passed to `np.ascontiguousarray`, which also converts arguments implicitly to numpy arrays, so this should work with the change as well.
- [shared/proxy.py](../blob/d9d4db7076c63ff39bc63f8bffd7acdcd0689cfe/makehuman/shared/proxy.py#L554): The return value is destructured to two variables. Numpy arrays support this so it isn't affcected by the change.