### PR TITLE
Fixing issues with pickMesh, queryDepth, and Frame._asWindowStateSet.

### DIFF
--- a/makehuman/lib/qtgui.py
+++ b/makehuman/lib/qtgui.py
@@ -1315,7 +1315,7 @@ class AboutBoxScrollbars(QtWidgets.QDialog):
         self.setModal(True)
         self.setAttribute(QtCore.Qt.WA_DeleteOnClose)
 
-        size = QtCore.QSize(min(parent.size().width(), width + 60), 0.8 * parent.size().height())
+        size = QtCore.QSize(min(parent.size().width(), width + 60), int(0.8 * parent.size().height()))
         self.resize(size)
 
 

--- a/makehuman/lib/qtui.py
+++ b/makehuman/lib/qtui.py
@@ -216,9 +216,11 @@ class Canvas(QtWidgets.QOpenGLWidget):
         return (relPos.x(), relPos.y())
 
     def mousePressEvent(self, ev):
+        self.makeCurrent()
         self.mouseUpDownEvent(ev, "onMouseDownCallback")
 
     def mouseReleaseEvent(self, ev):
+        self.makeCurrent()
         self.mouseUpDownEvent(ev, "onMouseUpCallback")
 
     def mouseUpDownEvent(self, ev, direction):
@@ -230,6 +232,7 @@ class Canvas(QtWidgets.QOpenGLWidget):
 
         gg_mouse_pos = x, y
 
+        self.makeCurrent()
         G.app.callEvent(direction, events3d.MouseEvent(b, x, y))
 
         # Update screen
@@ -250,6 +253,7 @@ class Canvas(QtWidgets.QOpenGLWidget):
             x = y = None
 
         b = 1 if d > 0 else -1
+        self.makeCurrent()
         G.app.callEvent('onMouseWheelCallback', events3d.MouseWheelEvent(b, x, y))
 
         if g_mousewheel_t is None or t - g_mousewheel_t > MOUSEWHEEL_PICK_TIMEOUT:
@@ -287,6 +291,7 @@ class Canvas(QtWidgets.QOpenGLWidget):
 
         buttons = int(G.app.mouseButtons())
 
+        self.makeCurrent()
         G.app.callEvent('onMouseMovedCallback', events3d.MouseEvent(buttons, x, y, xrel, yrel))
 
         if buttons:
@@ -585,8 +590,7 @@ class Frame(QtWidgets.QMainWindow):
             state.add('fullscreen')
         if stateflags & QtCore.Qt.WindowActive:
             state.add('active')
-        if not (stateflags &
-            (QtCore.Qt.WindowMaximized | QtCore.Qt.WindowFullScreen)):
+        if not(stateflags & QtCore.Qt.WindowMaximized) and not(stateflags & QtCore.Qt.WindowFullScreen):
             state.add('normal geometry')
             if not stateflags & QtCore.Qt.WindowMinimized:
                 state.add('normal')


### PR DESCRIPTION
I encountered three issues while running the program on Ubuntu 22.04.3 and have resolved them on my end. Testing in other environments may still be necessary.

A syntax error in `Frame._asWindowStateSet`'s implementation was reported when attempting to run the program. This has been resolved by changing the way that the `stateFlags` parameter was tested.

Dragging background images did not work. This was tracked down to the contents of the picking buffer not being changed by the call to `glDrawElements` in `pickMesh`. After ensuring that GL_VERTEX_ARRAY was enabled, the draw call changed the buffer as expected. This addresses [issue 231](https://github.com/makehumancommunity/makehuman/issues/231).

After fixing that issue, `queryDepth` was being called where it wasn't before, and the call to `glReadPixels` was throwing an OpenGL error. It seems that the active framebuffer did not have a depth buffer at the time of the call as `glGetIntegerv(GL_DEPTH_BUFFER_BITS)` reported zero despite reporting 24 in other places in the program. It was determined that this was because the appropriate context was not active at the time of the function's evaluation. Calls to `makeCurrent` in functions related to handling mouse events appears to resolve this issue.

Also addressed [issue 232](https://github.com/makehumancommunity/makehuman/issues/232) by adding cast to int.