### PR TITLE
Fix some exporter inheritance mistakes and add more BVH export options

### DIFF
--- a/makehuman/plugins/9_export_bvh/__init__.py
+++ b/makehuman/plugins/9_export_bvh/__init__.py
@@ -52,6 +52,8 @@ class BvhConfig(ExportConfig):
     def __init__(self):
         ExportConfig.__init__(self)
         self.useRelPaths = True
+        self.allowDummyJoints = True
+        self.sortJointChildrenByName = False
 
 class ExporterBVH(Exporter):
     def __init__(self):
@@ -63,13 +65,17 @@ class ExporterBVH(Exporter):
 
     def build(self, options, taskview):
         import gui
+        Exporter.build(self, options, taskview)
         self.taskview       = taskview
         #self.exportAnimations = options.addWidget(gui.CheckBox("Animations", True))
-        self.feetOnGround = options.addWidget(gui.CheckBox("Feet on ground", True))
+        self.allowDummyJoints = options.addWidget(gui.CheckBox("Allow dummy joints", True))
+        self.sortJointChildrenByName = options.addWidget(gui.CheckBox("Sort joint children by name", False))
 
     def getConfig(self):
         cfg = BvhConfig()
         cfg.feetOnGround      = self.feetOnGround.selected
+        cfg.allowDummyJoints  = self.allowDummyJoints.selected
+        cfg.sortJointChildrenByName  = self.sortJointChildrenByName.selected
         cfg.scale,cfg.unit    = self.taskview.getScale()
         #cfg.exportAnimations = self.exportAnimations.selected
         cfg.exportAnimations = False
@@ -90,7 +96,7 @@ class ExporterBVH(Exporter):
             for animName in human.getAnimations():
                 fn = baseFilename + "_%s.bvh" % animName
                 log.message("Exporting file %s.", fn)
-                bvhData = bvh.createFromSkeleton(skel, human.getAnimation(animName))
+                bvhData = bvh.createFromSkeleton(skel, human.getAnimation(animName), cfg.allowDummyJoints, cfg.sortJointChildrenByName)
                 if cfg.scale != 1:
                     bvhData.scale(cfg.scale)
                 if cfg.feetOnGround:
@@ -100,9 +106,9 @@ class ExporterBVH(Exporter):
             fn = filename("bvh")
             log.message("Exporting file %s.", fn)
             if human.isPosed():
-                bvhData = bvh.createFromSkeleton(skel, human.getActiveAnimation())
+                bvhData = bvh.createFromSkeleton(skel, human.getActiveAnimation(), cfg.allowDummyJoints, cfg.sortJointChildrenByName)
             else:
-                bvhData = bvh.createFromSkeleton(skel)
+                bvhData = bvh.createFromSkeleton(skel, None, cfg.allowDummyJoints, cfg.sortJointChildrenByName)
             if cfg.scale != 1:
                 bvhData.scale(cfg.scale)
             if cfg.feetOnGround:

--- a/makehuman/plugins/9_export_ogre/__init__.py
+++ b/makehuman/plugins/9_export_ogre/__init__.py
@@ -66,9 +66,8 @@ class ExporterOgre(Exporter):
         mh2ogre.exportOgreMesh(filename("mesh.xml"), cfg)
 
     def build(self, options, taskview):
-        import gui
+        Exporter.build(self, options, taskview)
         self.taskview     = taskview
-        self.feetOnGround = options.addWidget(gui.CheckBox("Feet on ground", True))
 
     def getConfig(self):
         cfg = OgreConfig()


### PR DESCRIPTION
This pull request will resolve some confusion surrounding the "Feet On Ground" export option for various asset file formats, as well as introduce extra options when exporting the animation/pose skeleton as BVH. This includes the exposure of "Dummy Joints" which before were always enabled by default, therefore unconditionally guaranteeing that the automated joint name retargeting procedure for whichever template was selected by the user will never yield discontiguous bones. Users should ideally be able to elect whether to exclude dummy joints, whose names feature a double under-score "__" prefix which can disrupt parity with certain skeleton templates such as the one for CMU motion capture data, and so it has been addressed here. Additionally, for the convenience of working within a project pipeline where animators must share motion data between different armatures in other tools outside the context of MakeHuman itself, a "Sort Joint Child By Name" option is also introduced so that the order of appearance for each child of a given joint node in the resultant BVH data is deterministic according to alphabetical sorting.