### PR TITLE
Reuse old value if an invalid number is used

### DIFF
--- a/makehuman/lib/qtgui.py
+++ b/makehuman/lib/qtgui.py
@@ -453,7 +453,11 @@ class Slider(QtWidgets.QWidget, Widget):
         if not text:
             return
         oldValue = self.getValue()
-        newValue = self.fromDisplay(float(text))
+        try:
+            newValue = self.fromDisplay(float(text))
+        except ValueError:
+            newValue = oldValue
+
         self.setValue(newValue)
         if abs(oldValue - newValue) > 1e-3:
             self.callEvent('onChanging', newValue)


### PR DESCRIPTION
If the user inputs an invalid number (something that causes a ValueError because it can't be converted to a float), set the number back to the previous value, and discard the user input.

Inputting an invalid number would crash makehuman before this fix.

Should resolve #252 