### PR TITLE
Add Perspective/Orthographic Mode Toggle and FOV Adjustment

### DIFF
--- a/makehuman/core/mhmain.py
+++ b/makehuman/core/mhmain.py
@@ -317,8 +317,8 @@ class MHApplication(gui3d.Application, mh.Application):
             self.updateFilenameCaption()
 
         #self.modelCamera = mh.Camera()
-        #self.modelCamera.switchToOrtho()
         self.modelCamera = mh.OrbitalCamera()
+        self.modelCamera.switchToOrtho()
         #self.modelCamera.debug = True
 
         @self.modelCamera.mhEvent
@@ -731,7 +731,9 @@ class MHApplication(gui3d.Application, mh.Application):
         height = cam.getScale()
         aspect = cam.getAspect()
         width = height * aspect
-        self.backgroundGradient.mesh.resize(2.1*width, 2.1*height)
+        factor = 2.1 if cam._projection == 0 else 16.1
+
+        self.backgroundGradient.mesh.resize(factor*width, factor*height)
 
         self.backgroundGradient.setPosition([0, 0, -0.85*cam.farPlane])
 

--- a/makehuman/core/mhmain.py
+++ b/makehuman/core/mhmain.py
@@ -731,7 +731,7 @@ class MHApplication(gui3d.Application, mh.Application):
         height = cam.getScale()
         aspect = cam.getAspect()
         width = height * aspect
-        factor = 2.1 if cam._projection == 0 else 16.1
+        factor = 2.1 if cam._projection == 0 else 79.1
 
         self.backgroundGradient.mesh.resize(factor*width, factor*height)
 

--- a/makehuman/lib/camera.py
+++ b/makehuman/lib/camera.py
@@ -36,6 +36,7 @@ Abstract
 TODO
 """
 
+from logging import setLogRecordFactory
 import math
 import numpy as np
 
@@ -441,6 +442,9 @@ class OrbitalCamera(Camera):
         self.radius = 1.0
         self._fovAngle = 90.0
 
+        self.minRadius = 10
+        self.maxRadius = 20
+        
         self.fixedRadius = False
         self.noAutoScale = False
         self.scaleTranslations = True  # Enable to make translations depend on zoom factor (only work when zoomed in)
@@ -567,7 +571,9 @@ class OrbitalCamera(Camera):
         maxDistance = math.sqrt( -distances[ np.argsort(distances)[0] ] )
 
         # Set radius as max distance from bounding box
-        self.radius = maxDistance + 1
+        self.minRadius = maxDistance
+        self.maxRadius = maxDistance + 10
+        self.radius = maxDistance + 1 if not self.projection else self.radius
 
         if self.debug:
             import log
@@ -654,36 +660,73 @@ class OrbitalCamera(Camera):
         else:
             self.zoomFactor = zoomFactor
 
+    def setRadius(self, radius):
+        if radius < self.minRadius:
+            self.radius = self.minRadius
+        elif radius > self.maxRadius:
+            self.radius = self.maxRadius
+        else:
+            self.radius = radius
+
     def addZoom(self, amount):
         self.setZoomFactor(self.zoomFactor - (amount/4.0))
         if self.debug:
             import log
             log.debug("OrbitalCamera zoom: %s", self.zoomFactor)
 
-        if self.pickedPos is not None:
-            if not self.scaleTranslations and -amount < 0.0:
-                amount = abs(amount) / max(1.0, min(5.0, self.zoomFactor))
-                for i in range(3):
-                    if self.translation[i] < 0.0:
-                        self.translation[i] += amount
-                        self.translation[i] = min(self.translation[i], 0.0)
-                    elif self.translation[i] > 0.0:
-                        self.translation[i] -= amount
-                        self.translation[i] = max(self.translation[i], 0.0)
+        if not self.projection:
+            if self.pickedPos is not None:
+                if not self.scaleTranslations and -amount < 0.0:
+                    amount = abs(amount) / max(1.0, min(5.0, self.zoomFactor))
+                    for i in range(3):
+                        if self.translation[i] < 0.0:
+                            self.translation[i] += amount
+                            self.translation[i] = min(self.translation[i], 0.0)
+                        elif self.translation[i] > 0.0:
+                            self.translation[i] -= amount
+                            self.translation[i] = max(self.translation[i], 0.0)
+                else:
+                    #amount = abs(amount/4.0)
+                    #amount = abs(amount) / self.zoomFactor
+                    amount = abs(amount) / max(1.0, min(5.0, self.zoomFactor))
+                    #amount = abs(amount) / max(1.0, 0.3 * self.zoomFactor)
+                    for i in range(3):
+                        if self.translation[i] < self.pickedPos[i]:
+                            self.translation[i] += amount
+                            self.translation[i] = min(self.translation[i], self.pickedPos[i])
+                        elif self.translation[i] > self.pickedPos[i]:
+                            self.translation[i] -= amount
+                            self.translation[i] = max(self.translation[i], self.pickedPos[i])
+                    if self.pickedPos == self.translation:
+                        self.pickedPos = None
+
+        else:
+            x, y, z = 0, 1, 2
+
+            dir = np.array([
+                self.pickedPos[x] - self.translation[x],
+                self.pickedPos[y] - self.translation[y],
+                self.pickedPos[z] - self.translation[z],
+            ]) if self.pickedPos else 0.2
+
+            # rot, incl = getRotationForDirection(dir)
+
+            if isinstance(self.translation, list):
+                self.translation = np.array(self.translation)
+
+            if amount > 0:
+                pos = self._getTranslationForPosition(self.translation + dir)
             else:
-                #amount = abs(amount/4.0)
-                #amount = abs(amount) / self.zoomFactor
-                amount = abs(amount) / max(1.0, min(5.0, self.zoomFactor))
-                #amount = abs(amount) / max(1.0, 0.3 * self.zoomFactor)
-                for i in range(3):
-                    if self.translation[i] < self.pickedPos[i]:
-                        self.translation[i] += amount
-                        self.translation[i] = min(self.translation[i], self.pickedPos[i])
-                    elif self.translation[i] > self.pickedPos[i]:
-                        self.translation[i] -= amount
-                        self.translation[i] = max(self.translation[i], self.pickedPos[i])
-                if self.pickedPos == self.translation:
-                    self.pickedPos = None
+                pos = self._getTranslationForPosition(self.translation - dir)
+
+            self.setRadius(self.radius + amount)
+            self.setPosition(pos)
+
+            #Update
+            G.app.redraw()
+            G.app.processEvents()
+
+
         self.changed()
 
     def getMatrices(self, eye=None):

--- a/makehuman/lib/camera.py
+++ b/makehuman/lib/camera.py
@@ -446,7 +446,7 @@ class OrbitalCamera(Camera):
         self.scaleTranslations = True  # Enable to make translations depend on zoom factor (only work when zoomed in)
 
         # Ortho mode
-        self._projection = 0    # TODO properly test with projection mode as well
+        self._projection = 1    # TODO properly test with projection mode as well
 
         self._horizontalRotation = 0.0
         self._verticalInclination = 0.0

--- a/makehuman/plugins/5_settings_camera.py
+++ b/makehuman/plugins/5_settings_camera.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+""" 
+**Project Name:**      MakeHuman
+
+**Product Home Page:** http://www.makehumancommunity.org/
+
+**Github Code Home Page:**    https://github.com/makehumancommunity/
+
+**Authors:**           Joel Palmius, Marc Flerackers
+
+**Copyright(c):**      MakeHuman Team 2001-2020
+
+**Licensing:**         AGPL3
+
+    This file is part of MakeHuman (www.makehumancommunity.org).
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+Abstract
+--------
+
+TODO
+"""
+
+
+import gui3d
+import mh
+import gui
+
+
+class CameraActionsTaskView(gui3d.TaskView):
+    def __init__(self, category) -> None:
+        super().__init__(self, category, 'Camera')
+
+        self.cameraBox = self.addLeftWidget(gui.GroupBox('Camera'))
+
+
+        self.orthogonal = self.cameraBox.addWidget(
+                gui.CheckBox(
+                    label = "Orthogonal/Perspective",
+                    selected = True if gui3d.app.modelCamera.getProjection() == 0 else False
+                )
+        )
+
+        self.fovAngle = self.cameraBox.addWidget(
+                gui.Slider(
+                    value = gui3d.app.modelCamera.getFovAngle(),
+                    min = 1, max = 171,
+                    label = ["Fov Angle",": %d"]
+                )
+        )
+
+
+        @self.orthogonal.mhEvent
+        def onClicked(event):
+            if self.orthogonal.selected == True:
+                gui3d.app.modelCamera.switchToOrtho()
+            else:
+                gui3d.app.modelCamera.switchToPerspective()
+
+
+        @self.fovAngle.mhEvent
+        def onChange(value):
+            gui3d.app.modelCamera.setFovAngle(value)
+
+    def onShow(self, event):
+        gui3d.TaskView.onShow(self, event)
+        # gui3d.app.statusPersist("Change camera settings")
+
+    def onHide(self, event):
+        # gui3d.app.statusPersist("")
+        gui3d.TaskView.onHide(self, event)
+
+
+def load(app):
+    category = app.getCategory('Settings')
+    taskview = category.addTask(CameraActionsTaskView(category))
+
+def unload(app):
+    pass


### PR DESCRIPTION
What do you think about adding a button to switch between perspective mode and orthographic mode?
I was a Makehuman user between 2014 and 2021 and I always ask me why its no posible change betwen Orthogonal and Perspective mode. I added a widget `Checkbox` to do easy chage modes, i too added a widget `Slider` to adjust `FOV Angle`.

Refactored the `addZoom` function to enhance zoom behavior in perspective projection. But I still think it needs to be improved.

https://github.com/user-attachments/assets/2e97bb5a-6d37-4d8c-962e-28612a763cf9

